### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.extensions.timelines.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.extensions.timelines)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.extensions.timelines.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.extensions.timelines)
 
 ## Overview
 
@@ -27,36 +27,36 @@ Within app developer accounts, you can create [developer test accounts](https://
 > **Note:** These accounts are only for development and testing purposes. In production you should not use developer test accounts.
 
 1. Go to test account section from the left sidebar.
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_1.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_1.png)
 
 2. Click create developer test account.
-   ![Hubspot developer testacc](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_2.png)
+   ![HubSpot developer testacc](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_2.png)
 
 3. In the dialogue box, give a name to your test account and click create.
-   ![Hubspot developer testacc3](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_3.png)
+   ![HubSpot developer testacc3](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_3.png)
 
 ### Step 3: Create a HubSpot app under your account
 
 1. In your developer account, navigate to the "Apps" section. Click on "Create App"
-   ![Hubspot app creation 1](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_1.png)
+   ![HubSpot app creation 1](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_1.png)
 
 2. Provide the necessary details, including the app name and description.
- ![Hubspot app creation 2](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_2.png)
+ ![HubSpot app creation 2](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_2.png)
 
 ### Step 4: Configure the authentication flow
 
 1. Move to the "Auth" Tab.
   
 2. In the "Scopes" section, add necessary scopes for your app using the "Add new scope" button.
-   ![Hubspot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/set_scope.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/set_scope.png)
 
 3. Add your redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click create app.
-   ![Hubspot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_final.png)
 
 ### Step 5: Get your client ID and client Secret
 
 Navigate to the auth section of your app. Make sure to save the provided client ID and client Secret.
-  ![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/get_credentials.png)
 
 ### Step 6: Setup authentication flow
 
@@ -115,7 +115,7 @@ Some APIs use a developer API key as a query parameter for authentication.
 
 1. In your developer account, navigate to Keys -> Developer API key. It will list down the active API key that you can copy.
 
-![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/developer_key.png)
+![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/developer_key.png)
 
 2. Use the key by appending it to API requests as a query parameter:
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -28,36 +28,36 @@ Within app developer accounts, you can create [developer test accounts](https://
 > **Note:** These accounts are only for development and testing purposes. In production you should not use developer test accounts.
 
 1. Go to test account section from the left sidebar.
-   ![Hubspot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_1.png)
+   ![HubSpot developer portal](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_1.png)
 
 2. Click create developer test account.
-   ![Hubspot developer testacc](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_2.png)
+   ![HubSpot developer testacc](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_2.png)
 
 3. In the dialogue box, give a name to your test account and click create.
-   ![Hubspot developer testacc3](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_3.png)
+   ![HubSpot developer testacc3](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/test_acc_3.png)
 
 ### Step 3: Create a HubSpot app under your account
 
 1. In your developer account, navigate to the "Apps" section. Click on "Create App"
-   ![Hubspot app creation 1](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_1.png)
+   ![HubSpot app creation 1](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_1.png)
 
 2. Provide the necessary details, including the app name and description.
- ![Hubspot app creation 2](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_2.png)
+ ![HubSpot app creation 2](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_2.png)
 
 ### Step 4: Configure the authentication flow
 
 1. Move to the "Auth" Tab.
 
 2. In the "Scopes" section, add necessary scopes for your app using the "Add new scope" button.
-   ![Hubspot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/set_scope.png)
+   ![HubSpot set scope](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/set_scope.png)
 
 3. Add your redirect URI in the relevant section. You can also use localhost addresses for local development purposes. Click create app.
-   ![Hubspot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_final.png)
+   ![HubSpot create app final](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/create_app_final.png)
 
 ### Step 5: Get your client ID and client Secret
 
 Navigate to the auth section of your app. Make sure to save the provided client ID and client Secret.
-  ![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/get_credentials.png)
+  ![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/get_credentials.png)
 
 ### Step 6: Setup authentication flow
 
@@ -116,7 +116,7 @@ Some APIs use a developer API key as a query parameter for authentication.
 
 1. In your developer account, navigate to Keys -> Developer API key. It will list down the active API key that you can copy.
 
-![Hubspot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/developer_key.png)
+![HubSpot get credentials](https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-hubspot.crm.extensions.timelines/refs/heads/main/docs/resources/developer_key.png)
 
 2. Use the key by appending it to API requests as a query parameter:
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector audit. Refs ballerina-platform/ballerina-library#8823.

## Goals

Apply the systemic README fixes that affect this connector so the README renders correctly on GitHub and uses the correct brand casing.

## Approach

- Replace `Hubspot` with `HubSpot` in brand-name occurrences (image alt-text). Package names, URLs, and code identifiers were left lowercase.
- Fix the encoding in the GitHub Issues badge link URL (`module%hubspot...` -> `module%2Fhubspot...`) so the badge link resolves to the issues label.

Affected files: `README.md`, `ballerina/README.md`. No code, build config, or `Ballerina.toml` changes.

## User stories

N/A -- documentation-only change.

## Release note

N/A -- documentation-only change.

## Documentation

This PR is the documentation update.

## Training

N/A -- documentation-only change.

## Certification

N/A -- documentation-only change.

## Marketing

N/A -- documentation-only change.

## Automation tests

- Unit tests
  > N/A -- documentation-only change.
- Integration tests
  > N/A -- documentation-only change.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A -- documentation-only change
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A -- documentation-only change.

## Related PRs

Refs ballerina-platform/ballerina-library#8823

## Migrations (if applicable)

N/A -- documentation-only change.

## Test environment

N/A -- documentation-only change. Verified the diff is restricted to README files.

## Learning

N/A -- documentation-only change.